### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
 


### PR DESCRIPTION
Potential fix for [https://github.com/usabarashi/pycategory/security/code-scanning/1](https://github.com/usabarashi/pycategory/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function. Since the workflow only checks out the repository and runs tests, it only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` used in the workflow has minimal access, reducing the risk of unintended or malicious actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
